### PR TITLE
Adds Competition & Testing tab modes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,8 +136,10 @@ compileJava.dependsOn 'spotlessApply'
 
 task copyElasticConfig(type: Copy){
     dependsOn compileJava
-    from("${buildDir}/generated/sources/annotationProcessor/java/main/deploy/elastic-dashboard.json")
+    from("${buildDir}/generated/sources/annotationProcessor/java/main/deploy")
+    include("elastic-*.json")
     into("${projectDir}/src/main/deploy")
 }
 
 jar.dependsOn copyElasticConfig
+

--- a/src/main/deploy/elastic-competition.json
+++ b/src/main/deploy/elastic-competition.json
@@ -1,0 +1,363 @@
+{
+  "version" : 1.0,
+  "grid_size" : 128.0,
+  "tabs" : [ {
+    "name" : "Operator",
+    "grid_layout" : {
+      "layouts" : [ ],
+      "containers" : [ {
+        "title" : "Autonomous Start Side",
+        "type" : "Split Button Chooser",
+        "x" : 1152.0,
+        "y" : 256.0,
+        "width" : 384.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Autonomous Start Side",
+          "period" : 0.06
+        }
+      }, {
+        "title" : "Autonomous Routine",
+        "type" : "ComboBox Chooser",
+        "x" : 1152.0,
+        "y" : 384.0,
+        "width" : 384.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Autonomous Routine",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
+        "title" : "Autonomous Delay",
+        "type" : "ComboBox Chooser",
+        "x" : 1152.0,
+        "y" : 512.0,
+        "width" : 384.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Autonomous Delay",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
+        "title" : "Alerts",
+        "type" : "Alerts",
+        "x" : 0.0,
+        "y" : 512.0,
+        "width" : 896.0,
+        "height" : 256.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Alerts",
+          "period" : 0.06
+        }
+      }, {
+        "title" : "Field",
+        "type" : "Field",
+        "x" : 0.0,
+        "y" : 0.0,
+        "width" : 896.0,
+        "height" : 512.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Field",
+          "period" : 0.06,
+          "field_game" : "Rebuilt",
+          "robot_width" : 0.85,
+          "robot_length" : 0.85,
+          "show_other_objects" : true,
+          "show_trajectories" : true,
+          "field_rotation" : 0.0,
+          "robot_color" : -65536,
+          "trajectory_color" : -1
+        }
+      }, {
+        "title" : "Match Time",
+        "type" : "Match Time",
+        "x" : 1152.0,
+        "y" : 0.0,
+        "width" : 384.0,
+        "height" : 256.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Match Time",
+          "period" : 0.06,
+          "time_display_mode" : "Minutes and Seconds",
+          "yellow_start_time" : 30,
+          "red_start_time" : 15
+        }
+      }, {
+        "title" : "Front Left Camera Connected",
+        "type" : "Boolean Box",
+        "x" : 896.0,
+        "y" : 256.0,
+        "width" : 128.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Front Left Camera Connected",
+          "period" : 0.06,
+          "true_color" : -16711936,
+          "true_icon" : "None",
+          "false_color" : -65536,
+          "false_icon" : "None"
+        }
+      }, {
+        "title" : "Front Right Camera Connected",
+        "type" : "Boolean Box",
+        "x" : 1024.0,
+        "y" : 256.0,
+        "width" : 128.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Front Right Camera Connected",
+          "period" : 0.06,
+          "true_color" : -16711936,
+          "true_icon" : "None",
+          "false_color" : -65536,
+          "false_icon" : "None"
+        }
+      }, {
+        "title" : "Back Left Camera Connected",
+        "type" : "Boolean Box",
+        "x" : 896.0,
+        "y" : 384.0,
+        "width" : 128.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Back Left Camera Connected",
+          "period" : 0.06,
+          "true_color" : -16711936,
+          "true_icon" : "None",
+          "false_color" : -65536,
+          "false_icon" : "None"
+        }
+      }, {
+        "title" : "Back Right Camera Connected",
+        "type" : "Boolean Box",
+        "x" : 1024.0,
+        "y" : 384.0,
+        "width" : 128.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Back Right Camera Connected",
+          "period" : 0.06,
+          "true_color" : -16711936,
+          "true_icon" : "None",
+          "false_color" : -65536,
+          "false_icon" : "None"
+        }
+      }, {
+        "title" : "Within Range",
+        "type" : "Boolean Box",
+        "x" : 896.0,
+        "y" : 0.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Within Range",
+          "period" : 0.06,
+          "true_color" : -16711936,
+          "true_icon" : "None",
+          "false_color" : -65536,
+          "false_icon" : "None"
+        }
+      }, {
+        "title" : "Aligned to Hub",
+        "type" : "Boolean Box",
+        "x" : 896.0,
+        "y" : 128.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Aligned to Hub",
+          "period" : 0.06,
+          "true_color" : -16711936,
+          "true_icon" : "None",
+          "false_color" : -65536,
+          "false_icon" : "None"
+        }
+      }, {
+        "title" : "Set Extended Position",
+        "type" : "Command",
+        "x" : 896.0,
+        "y" : 512.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Set Extended Position",
+          "period" : 0.06,
+          "show_type" : true,
+          "maximize_button_space" : true
+        }
+      }, {
+        "title" : "Set Stowed Position",
+        "type" : "Command",
+        "x" : 896.0,
+        "y" : 640.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Operator/Set Stowed Position",
+          "period" : 0.06,
+          "show_type" : true,
+          "maximize_button_space" : true
+        }
+      } ]
+    }
+  }, {
+    "name" : "Preferences",
+    "grid_layout" : {
+      "layouts" : [ {
+        "title" : "April Tag",
+        "type" : "List Layout",
+        "x" : 640.0,
+        "y" : 0.0,
+        "width" : 256.0,
+        "height" : 384.0,
+        "properties" : {
+          "label_position" : "TOP"
+        },
+        "children" : [ {
+          "title" : "Enable Front Left",
+          "type" : "Toggle Switch",
+          "x" : 0.0,
+          "y" : 0.0,
+          "width" : 128.0,
+          "height" : 128.0,
+          "properties" : {
+            "topic" : "/SmartDashboard/Preferences/April Tag/Enable Front Left",
+            "period" : 0.06
+          }
+        }, {
+          "title" : "Enable Front Right",
+          "type" : "Toggle Switch",
+          "x" : 0.0,
+          "y" : 0.0,
+          "width" : 128.0,
+          "height" : 128.0,
+          "properties" : {
+            "topic" : "/SmartDashboard/Preferences/April Tag/Enable Front Right",
+            "period" : 0.06
+          }
+        }, {
+          "title" : "Enable Back Left",
+          "type" : "Toggle Switch",
+          "x" : 0.0,
+          "y" : 0.0,
+          "width" : 128.0,
+          "height" : 128.0,
+          "properties" : {
+            "topic" : "/SmartDashboard/Preferences/April Tag/Enable Back Left",
+            "period" : 0.06
+          }
+        }, {
+          "title" : "Enable Back Right",
+          "type" : "Toggle Switch",
+          "x" : 0.0,
+          "y" : 0.0,
+          "width" : 128.0,
+          "height" : 128.0,
+          "properties" : {
+            "topic" : "/SmartDashboard/Preferences/April Tag/Enable Back Right",
+            "period" : 0.06
+          }
+        } ]
+      } ],
+      "containers" : [ {
+        "title" : "Field Layout",
+        "type" : "ComboBox Chooser",
+        "x" : 896.0,
+        "y" : 0.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Field Layout",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
+        "title" : "Pose Est. Strategy",
+        "type" : "ComboBox Chooser",
+        "x" : 896.0,
+        "y" : 128.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Pose Est. Strategy",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
+        "title" : "Auto Override Odometry With Pose",
+        "type" : "Toggle Switch",
+        "x" : 896.0,
+        "y" : 256.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Auto Override Odometry With Pose",
+          "period" : 0.06
+        }
+      }, {
+        "title" : "Robot Selector",
+        "type" : "ComboBox Chooser",
+        "x" : 0.0,
+        "y" : 0.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Robot Selector",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
+        "title" : "Dashboard Mode",
+        "type" : "ComboBox Chooser",
+        "x" : 0.0,
+        "y" : 128.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Dashboard Mode",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
+        "title" : "Auto Rotation PID",
+        "type" : "PID Controller",
+        "x" : 384.0,
+        "y" : 128.0,
+        "width" : 256.0,
+        "height" : 384.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Auto Rotation PID",
+          "period" : 0.06
+        }
+      }, {
+        "title" : "Enable Rumble",
+        "type" : "Toggle Switch",
+        "x" : 256.0,
+        "y" : 0.0,
+        "width" : 128.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Enable Rumble",
+          "period" : 0.06
+        }
+      }, {
+        "title" : "Right Trigger Scalar",
+        "type" : "Number Slider",
+        "x" : 384.0,
+        "y" : 0.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Right Trigger Scalar",
+          "period" : 0.06,
+          "min_value" : 0.0,
+          "max_value" : 1.0,
+          "divisions" : 5,
+          "publish_all" : false
+        }
+      } ]
+    }
+  } ]
+}

--- a/src/main/deploy/elastic-testing.json
+++ b/src/main/deploy/elastic-testing.json
@@ -309,6 +309,18 @@
           "sort_options" : false
         }
       }, {
+        "title" : "Dashboard Mode",
+        "type" : "ComboBox Chooser",
+        "x" : 0.0,
+        "y" : 128.0,
+        "width" : 256.0,
+        "height" : 128.0,
+        "properties" : {
+          "topic" : "/SmartDashboard/Preferences/Dashboard Mode",
+          "period" : 0.06,
+          "sort_options" : false
+        }
+      }, {
         "title" : "Auto Rotation PID",
         "type" : "PID Controller",
         "x" : 384.0,

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,8 @@
  
 package frc.robot;
 
+import static frc.robot.RobotPreferences.DASHBOARD_MODE;
+
 import com.nrg948.dashboard.DashboardServer;
 import com.nrg948.dashboard.annotations.Dashboard;
 import edu.wpi.first.wpilibj.TimedRobot;
@@ -36,7 +38,7 @@ public class Robot extends TimedRobot {
     // autonomous chooser on the dashboard.
     robotContainer = new RobotContainer();
 
-    dashboardServer = DashboardServer.start(this);
+    dashboardServer = DashboardServer.start(this, DASHBOARD_MODE.getValue().toString());
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -48,10 +48,14 @@ public class RobotContainer {
   private final CommandXboxController driverController =
       new CommandXboxController(OperatorConstants.DRIVER_CONTROLLER_PORT);
 
-  @DashboardTab(title = "Operator")
+  @DashboardTab(
+      title = "Operator",
+      modes = {"Competition", "Testing"})
   private final RobotOperator operator;
 
-  @DashboardTab(title = "Preferences")
+  @DashboardTab(
+      title = "Preferences",
+      modes = {"Competition", "Testing"})
   private final RobotPreferences preferences = new RobotPreferences();
 
   private final Subsystems subsystems = new Subsystems();

--- a/src/main/java/frc/robot/RobotPreferences.java
+++ b/src/main/java/frc/robot/RobotPreferences.java
@@ -19,6 +19,7 @@ import com.nrg948.preferences.EnumPreference;
 import com.nrg948.preferences.PIDControllerPreference;
 import frc.robot.parameters.AprilTagFieldParameters;
 import frc.robot.parameters.PoseEstimationStrategy;
+import frc.robot.util.DashboardMode;
 
 /** Defines robot preferences that can be adjusted via the dashboard. */
 @DashboardDefinition
@@ -86,6 +87,10 @@ public final class RobotPreferences {
   @DashboardComboBoxChooser(title = "Robot Selector", column = 0, row = 0, width = 2, height = 1)
   public static final EnumPreference<RobotSelector> ROBOT_TYPE =
       new EnumPreference<>("Robot", "Robot Type", RobotSelector.CompetitionRobot2026);
+
+  @DashboardComboBoxChooser(title = "Dashboard Mode", column = 0, row = 1, width = 2, height = 1)
+  public static EnumPreference<DashboardMode> DASHBOARD_MODE =
+      new EnumPreference<DashboardMode>("Dashboard", "Dashboard Mode", DashboardMode.COMPETITION);
 
   /** Selects the auto-rotation PID controller gains. */
   @DashboardPIDController(title = "Auto Rotation PID", column = 3, row = 1, width = 2, height = 3)

--- a/src/main/java/frc/robot/subsystems/Subsystems.java
+++ b/src/main/java/frc/robot/subsystems/Subsystems.java
@@ -22,27 +22,41 @@ import java.util.stream.Collectors;
 
 public final class Subsystems {
 
-  @DashboardTab(title = "Swerve")
+  @DashboardTab(
+      title = "Swerve",
+      modes = {"Testing"})
   public final Swerve drivetrain = new Swerve();
 
-  @DashboardTab(title = "Intake")
+  @DashboardTab(
+      title = "Intake",
+      modes = {"Testing"})
   public final Intake intake = new Intake();
 
-  @DashboardTab(title = "IntakeArm")
+  @DashboardTab(
+      title = "IntakeArm",
+      modes = {"Testing"})
   public final IntakeArm intakeArm = new IntakeArm();
 
-  @DashboardTab(title = "Shooter")
+  @DashboardTab(
+      title = "Shooter",
+      modes = {"Testing"})
   public final Shooter shooter = new Shooter();
 
-  @DashboardTab(title = "Indexer")
+  @DashboardTab(
+      title = "Indexer",
+      modes = {"Testing"})
   public final Indexer indexer = new Indexer();
 
-  @DashboardTab(title = "Hopper")
+  @DashboardTab(
+      title = "Hopper",
+      modes = {"Testing"})
   public final Hopper hopper = new Hopper();
 
   public final StatusLED statusLEDs = new StatusLED();
 
-  @DashboardTab(title = "Front Left Camera")
+  @DashboardTab(
+      title = "Front Left Camera",
+      modes = {"Testing"})
   public final Optional<AprilTag> frontLeftCamera =
       AprilTag.PARAMETERS
           .frontLeft()
@@ -56,7 +70,9 @@ public final class Subsystems {
                       c.cameraPublisherName(),
                       c.streamURL()));
 
-  @DashboardTab(title = "Front Right Camera")
+  @DashboardTab(
+      title = "Front Right Camera",
+      modes = {"Testing"})
   public final Optional<AprilTag> frontRightCamera =
       AprilTag.PARAMETERS
           .frontRight()
@@ -70,7 +86,9 @@ public final class Subsystems {
                       c.cameraPublisherName(),
                       c.streamURL()));
 
-  @DashboardTab(title = "Back Left Camera")
+  @DashboardTab(
+      title = "Back Left Camera",
+      modes = {"Testing"})
   public final Optional<AprilTag> backLeftCamera =
       AprilTag.PARAMETERS
           .backLeft()
@@ -84,7 +102,9 @@ public final class Subsystems {
                       c.cameraPublisherName(),
                       c.streamURL()));
 
-  @DashboardTab(title = "Back Right Camera")
+  @DashboardTab(
+      title = "Back Right Camera",
+      modes = {"Testing"})
   public final Optional<AprilTag> backRightCamera =
       AprilTag.PARAMETERS
           .backRight()

--- a/src/main/java/frc/robot/util/DashboardMode.java
+++ b/src/main/java/frc/robot/util/DashboardMode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Newport Robotics Group. All Rights Reserved.
+ *
+ * Open Source Software; you can modify and/or share it under the terms of
+ * the license file in the root directory of this project.
+ */
+ 
+package frc.robot.util;
+
+/** Enum representing the different dashboard modes. */
+public enum DashboardMode {
+  /** Competition mode. */
+  COMPETITION("Competition"),
+  /** Testing mode. */
+  TESTING("Testing");
+
+  private final String modeName;
+
+  /** Constructor for DashboardMode enum. */
+  DashboardMode(String modeName) {
+    this.modeName = modeName;
+  }
+
+  @Override
+  public String toString() {
+    return modeName;
+  }
+}

--- a/src/main/java/frc/robot/util/MatchUtil.java
+++ b/src/main/java/frc/robot/util/MatchUtil.java
@@ -9,6 +9,7 @@ package frc.robot.util;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.DriverStation.MatchType;
 
 /** Utility class for match-related information and timing. */
 public final class MatchUtil {
@@ -34,6 +35,11 @@ public final class MatchUtil {
   /** {@return the current match time in seconds} */
   public static double getMatchTime() {
     return DriverStation.getMatchTime();
+  }
+
+  /** {@return true if the match is a competition or practice match, false otherwise} */
+  public static boolean isCompetition() {
+    return DriverStation.getMatchType() != MatchType.None;
   }
 
   /** {@return true if the robot is in teleoperated mode} */


### PR DESCRIPTION
This change adds two dashboard modes: Competition and Testing. In "Competition" mode, only the "Operator" and "Preferences" tabs are displayed and data published to Network Tables. In "Testing" mode, all subsystem dashboards are displayed and data published to Network Tables in addition to the "Operator" and "Preferences" tabs. The mode is selectable via a preference accessible in the "Preferences" tab.

An Elastic configuration file is generated for each mode, `elastic-competition.json` and `elastic-testing.json`, respectively.